### PR TITLE
Bump opentracing version to 0.30.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ homepage := Some(url("https://git.lucidchart.com/lucidsoftware/opentracing-zipki
 javacOptions in (Compile, compile) += "-Xlint:unchecked"
 
 libraryDependencies ++= Seq(
-  "io.opentracing" % "opentracing-api" % "0.20.7",
+  "io.opentracing" % "opentracing-api" % "0.30.0",
   "io.zipkin.reporter" % "zipkin-reporter" % "0.6.12"
 )
 


### PR DESCRIPTION
Adds support for the `ActiveSpanSource` which can be provided through the new
`withActiveSpanSource(..)` builder method.